### PR TITLE
Add simple login demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>ログイン</h1>
+    <form id="login-form">
+        <div>
+            <label for="email">メールアドレス:</label>
+            <input type="email" id="email" required>
+        </div>
+        <div>
+            <label for="password">パスワード:</label>
+            <input type="password" id="password" required>
+        </div>
+        <button type="submit">ログイン</button>
+    </form>
+    <p id="error-message" style="color: red;"></p>
+
+    <script src="main.js"></script>
+</body>
+</html>

--- a/main.html
+++ b/main.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Main Menu</title>
+</head>
+<body>
+    <h1>メインメニュー</h1>
+    <p>ログイン成功しました。</p>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,26 @@
+const DEFAULT_EMAIL = 'admin@karaoke.jp';
+const DEFAULT_PASSWORD = '12345678';
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (!localStorage.getItem('email')) {
+    localStorage.setItem('email', DEFAULT_EMAIL);
+    localStorage.setItem('password', DEFAULT_PASSWORD);
+  }
+
+  const form = document.getElementById('login-form');
+  const errorMessage = document.getElementById('error-message');
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const email = document.getElementById('email').value;
+    const password = document.getElementById('password').value;
+    const storedEmail = localStorage.getItem('email');
+    const storedPassword = localStorage.getItem('password');
+
+    if (email === storedEmail && password === storedPassword) {
+      window.location.href = 'main.html';
+    } else {
+      errorMessage.textContent = "メールアドレスまたはパスワードが正しくありません";
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a login page with email/password
- check credentials stored in localStorage and redirect on success
- show an error message on failure
- add main menu page

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68428143a3f48333897b0828ba6f9516