### PR TITLE
Add active bill management pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ This repository contains a simple web-based application for managing bills at a 
 - `index.html` – login screen.
 - `main.html` – main menu with navigation buttons.
 - `bills.html` – bill management screen.
+- `new.html` – create a new bill.
+- `active.html` – list active bills.
+- `paid.html` – list paid bills.
 - `payment.html` – placeholder for payment features.
 - `admin.html` – placeholder for admin features.
 - `main.js` – common JavaScript for login and navigation logic.

--- a/active.html
+++ b/active.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>入店中</title>
+</head>
+<body>
+    <h1>入店中</h1>
+    <div id="active-list"></div>
+    <button id="back-bills">戻る</button>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,227 @@
 const DEFAULT_EMAIL = 'admin@karaoke.jp';
 const DEFAULT_PASSWORD = '12345678';
 
+// Utility to read/write bill arrays
+function loadBills(key) {
+    return JSON.parse(localStorage.getItem(key) || '[]');
+}
+
+function saveBills(key, bills) {
+    localStorage.setItem(key, JSON.stringify(bills));
+}
+
+function generateBillId() {
+    const date = new Date();
+    const ymd = date.toISOString().slice(0,10).replace(/-/g,'');
+    const seqKey = 'bill-seq-' + ymd;
+    let seq = parseInt(localStorage.getItem(seqKey) || '0', 10) + 1;
+    localStorage.setItem(seqKey, seq);
+    return ymd + '-' + seq;
+}
+
+function calcExtension(startTime, people) {
+    if (!startTime) return 0;
+    const base = 80 * 60 * 1000; // 80 minutes
+    const diff = Date.now() - startTime;
+    if (diff <= base) return 0;
+    const extraHours = Math.ceil((diff - base) / (60 * 60 * 1000));
+    return extraHours * people * 500;
+}
+
+// Initialize invoice creation page
+function initNewBillPage() {
+    const bill = {
+        id: generateBillId(),
+        name: '',
+        seat: '',
+        male: 0,
+        female: 0,
+        plan2500: 0,
+        plan3000: 0,
+        optionalPlans: [],
+        staffD: [],
+        staffT: [],
+        startTime: null,
+        status: 'new',
+        total: 0
+    };
+    document.getElementById('bill-id').textContent = bill.id;
+
+    function updateTotal() {
+        let total = bill.plan2500 * 2500 + bill.plan3000 * 3000;
+        bill.optionalPlans.forEach(p => { total += p.price * p.count; });
+        bill.staffD.forEach(s => { total += 600 * s.count; });
+        bill.staffT.forEach(s => { total += 1000 * s.count; });
+        total += calcExtension(bill.startTime, bill.male + bill.female);
+        bill.total = total;
+        document.getElementById('total').textContent = total;
+    }
+
+    function setupCounter(decBtnId, incBtnId, prop) {
+        const dec = document.getElementById(decBtnId);
+        const inc = document.getElementById(incBtnId);
+        const span = document.getElementById(prop + '-count');
+        dec.addEventListener('click', () => {
+            if (bill[prop] > 0) bill[prop]--;
+            span.textContent = bill[prop];
+            updateTotal();
+        });
+        inc.addEventListener('click', () => {
+            bill[prop]++;
+            span.textContent = bill[prop];
+            updateTotal();
+        });
+    }
+
+    setupCounter('male-dec','male-inc','male');
+    setupCounter('female-dec','female-inc','female');
+    setupCounter('plan2500-dec','plan2500-inc','plan2500');
+    setupCounter('plan3000-dec','plan3000-inc','plan3000');
+
+    document.getElementById('add-optional-plan').addEventListener('click', () => {
+        const container = document.getElementById('optional-plans-container');
+        const div = document.createElement('div');
+        const nameInput = document.createElement('input');
+        nameInput.placeholder = '項目';
+        const priceInput = document.createElement('input');
+        priceInput.type = 'text';
+        priceInput.placeholder = '金額';
+        const dec = document.createElement('button');
+        dec.textContent = '-';
+        const span = document.createElement('span');
+        span.textContent = '0';
+        const inc = document.createElement('button');
+        inc.textContent = '+';
+        const remove = document.createElement('button');
+        remove.textContent = '削除';
+        const item = {name:'',price:0,count:0};
+        bill.optionalPlans.push(item);
+        function sync() {
+            item.name = nameInput.value;
+            item.price = parseInt(priceInput.value || '0',10);
+            span.textContent = item.count;
+            updateTotal();
+        }
+        dec.addEventListener("click", () => { if (item.count > 0) { item.count--; sync(); } });
+        inc.addEventListener("click", () => { item.count++; sync(); });
+        nameInput.addEventListener('input',sync);
+        priceInput.addEventListener('input',sync);
+        remove.addEventListener('click',()=>{
+            bill.optionalPlans = bill.optionalPlans.filter(p=>p!==item);
+            container.removeChild(div);
+            updateTotal();
+        });
+        div.appendChild(nameInput);
+        div.appendChild(priceInput);
+        div.appendChild(dec);
+        div.appendChild(span);
+        div.appendChild(inc);
+        div.appendChild(remove);
+        container.appendChild(div);
+    });
+
+
+    function createStaffRow(container, price, array) {
+        const div = document.createElement('div');
+        const nameInput = document.createElement('input');
+        nameInput.setAttribute('list', container.id + '-list');
+        const dec = document.createElement('button');
+        dec.textContent = '-';
+        const span = document.createElement('span');
+        span.textContent = '0';
+        const inc = document.createElement('button');
+        inc.textContent = '+';
+        const remove = document.createElement('button');
+        remove.textContent = '削除';
+        const item = {name:'',count:0};
+        array.push(item);
+        function sync() {
+            item.name = nameInput.value;
+            span.textContent = item.count;
+            updateTotal();
+        }
+        dec.addEventListener("click", () => { if (item.count > 0) { item.count--; sync(); } });
+        inc.addEventListener("click", () => { item.count++; sync(); });
+        nameInput.addEventListener('input',sync);
+        remove.addEventListener('click',()=>{
+            array.splice(array.indexOf(item),1);
+            container.removeChild(div);
+            updateTotal();
+        });
+        div.appendChild(nameInput);
+        div.appendChild(dec);
+        div.appendChild(span);
+        div.appendChild(inc);
+        div.appendChild(remove);
+        container.appendChild(div);
+    }
+
+    document.getElementById('add-staff-d').addEventListener('click', () => {
+        const container = document.getElementById('staff-d-container');
+        createStaffRow(container, 600, bill.staffD);
+    });
+
+    document.getElementById('add-staff-t').addEventListener('click', () => {
+        const container = document.getElementById('staff-t-container');
+        createStaffRow(container, 1000, bill.staffT);
+    });
+
+    document.getElementById('start-btn').addEventListener('click', () => {
+        bill.name = document.getElementById('bill-name').value;
+        const seat = document.querySelector('input[name="seat"]:checked');
+        bill.seat = seat ? seat.value : '';
+        bill.startTime = Date.now();
+        bill.status = 'active';
+        updateTotal();
+        const bills = loadBills('bills');
+        bills.push(bill);
+        saveBills('bills', bills);
+        window.location.href = 'active.html';
+    });
+}
+
+function renderActiveBills() {
+    const container = document.getElementById('active-list');
+    if (!container) return;
+    const bills = loadBills('bills');
+    container.innerHTML = '';
+    bills.forEach(bill => {
+        const div = document.createElement('div');
+        div.textContent = `${bill.id} ${bill.name} 合計${bill.total}円`;
+        const payBtn = document.createElement('button');
+        payBtn.textContent = '精算';
+        payBtn.addEventListener('click', () => {
+            const active = loadBills('bills');
+            const idx = active.findIndex(b => b.id === bill.id);
+            if (idx !== -1) {
+                const [b] = active.splice(idx, 1);
+                b.status = 'paid';
+                const paid = loadBills('paidBills');
+                paid.push(b);
+                saveBills('bills', active);
+                saveBills('paidBills', paid);
+                renderActiveBills();
+            }
+        });
+        div.appendChild(payBtn);
+        container.appendChild(div);
+    });
+}
+
+function renderPaidBills() {
+    const container = document.getElementById('paid-list');
+    if (!container) return;
+    const bills = loadBills('paidBills');
+    container.innerHTML = '';
+    bills.forEach(bill => {
+        const div = document.createElement('div');
+        div.textContent = `${bill.id} ${bill.name} 合計${bill.total}円`;
+        container.appendChild(div);
+    });
+}
+
+// main entry
+
 document.addEventListener('DOMContentLoaded', () => {
     if (!localStorage.getItem('email')) {
         localStorage.setItem('email', DEFAULT_EMAIL);
@@ -31,6 +252,27 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    const inStoreBtn = document.getElementById('in-store');
+    if (inStoreBtn) {
+        inStoreBtn.addEventListener('click', () => {
+            window.location.href = 'active.html';
+        });
+    }
+
+    const paidBtn = document.getElementById('paid');
+    if (paidBtn) {
+        paidBtn.addEventListener('click', () => {
+            window.location.href = 'paid.html';
+        });
+    }
+
+    const newBillBtn = document.getElementById('new-bill');
+    if (newBillBtn) {
+        newBillBtn.addEventListener('click', () => {
+            window.location.href = 'new.html';
+        });
+    }
+
     const paymentBtn = document.getElementById('payment-btn');
     if (paymentBtn) {
         paymentBtn.addEventListener('click', () => {
@@ -43,5 +285,32 @@ document.addEventListener('DOMContentLoaded', () => {
         adminBtn.addEventListener('click', () => {
             window.location.href = 'admin.html';
         });
+    }
+
+    const backBills = document.getElementById('back-bills');
+    if (backBills) {
+        backBills.addEventListener('click', () => {
+            window.location.href = 'bills.html';
+        });
+    }
+
+    const backBillsPaid = document.getElementById('back-bills-paid');
+    if (backBillsPaid) {
+        backBillsPaid.addEventListener('click', () => {
+            window.location.href = 'bills.html';
+        });
+    }
+
+    const startBtn = document.getElementById('start-btn');
+    if (startBtn) {
+        initNewBillPage();
+    }
+
+    if (document.getElementById('active-list')) {
+        renderActiveBills();
+    }
+
+    if (document.getElementById('paid-list')) {
+        renderPaidBills();
     }
 });

--- a/new.html
+++ b/new.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>New Bill</title>
+</head>
+<body>
+    <h1>新規伝票作成</h1>
+    <div>伝票番号: <span id="bill-id"></span></div>
+    <div>
+        <label>伝票名: <input type="text" id="bill-name"></label>
+    </div>
+    <div>
+        席:
+        <label><input type="radio" name="seat" value="C">C</label>
+        <label><input type="radio" name="seat" value="B入口">B入口</label>
+        <label><input type="radio" name="seat" value="B奥">B奥</label>
+        <label><input type="radio" name="seat" value="Z">Z</label>
+    </div>
+    <div>
+        男性: <button type="button" id="male-dec">-</button>
+        <span id="male-count">0</span>
+        <button type="button" id="male-inc">+</button>
+    </div>
+    <div>
+        女性: <button type="button" id="female-dec">-</button>
+        <span id="female-count">0</span>
+        <button type="button" id="female-inc">+</button>
+    </div>
+    <div>
+        <h3>プラン</h3>
+        <div>2500円: <button type="button" id="plan2500-dec">-</button>
+            <span id="plan2500-count">0</span>
+            <button type="button" id="plan2500-inc">+</button>
+        </div>
+        <div>3000円: <button type="button" id="plan3000-dec">-</button>
+            <span id="plan3000-count">0</span>
+            <button type="button" id="plan3000-inc">+</button>
+        </div>
+    </div>
+    <div id="optional-plans-container">
+        <h3>任意プラン</h3>
+    </div>
+    <button type="button" id="add-optional-plan">任意プランを追加</button>
+    <div id="staff-d-container">
+        <h3>スタッフD (600円/杯)</h3>
+    </div>
+    <datalist id="staff-d-container-list">
+        <option value="春">
+        <option value="喜瀬">
+        <option value="水口">
+        <option value="北尾">
+        <option value="譜久村">
+        <option value="加藤">
+    </datalist>
+    <button type="button" id="add-staff-d">スタッフDを追加</button>
+    <div id="staff-t-container">
+        <h3>スタッフT (1000円/杯)</h3>
+    </div>
+    <datalist id="staff-t-container-list">
+        <option value="春">
+        <option value="喜瀬">
+        <option value="水口">
+        <option value="北尾">
+        <option value="譜久村">
+        <option value="加藤">
+    </datalist>
+    <button type="button" id="add-staff-t">スタッフTを追加</button>
+    <div>
+        合計金額: <span id="total">0</span>円
+    </div>
+    <button type="button" id="start-btn">開始</button>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/paid.html
+++ b/paid.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>清算済み</title>
+</head>
+<body>
+    <h1>清算済み</h1>
+    <div id="paid-list"></div>
+    <button id="back-bills-paid">戻る</button>
+    <script src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support staff name selection with datalist
- remove spinner from optional plan price field
- calculate extensions after 80 minutes
- list active and paid bills with simple pages
- update README

## Testing
- `node -e "require('./main.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68428f1bcbdc8333bd36b9da63df15bd