### PR TITLE
Implement active bill recalculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains a simple web-based application for managing bills at a 
 - `index.html` – login screen.
 - `main.html` – main menu with navigation buttons.
 - `bills.html` – bill management screen.
+- `active.html` – list of currently active bills.
+- `paid.html` – list of paid bills.
 - `payment.html` – placeholder for payment features.
 - `admin.html` – placeholder for admin features.
 - `main.js` – common JavaScript for login and navigation logic.

--- a/active.html
+++ b/active.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>入店中</title>
+</head>
+<body>
+    <h1>入店中一覧</h1>
+    <div id="active-list"></div>
+    <button id="back">戻る</button>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/paid.html
+++ b/paid.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>清算済</title>
+</head>
+<body>
+    <h1>清算済一覧</h1>
+    <div id="paid-list"></div>
+    <button id="back">戻る</button>
+    <script src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add active and paid bills pages
- compute totals on the fly in `renderActiveBills`
- move bills to `paidBills` via `payBill` handler
- update README for new pages

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842950ce4dc8333b1d991c199bdc57d