### PR TITLE
Add bill management usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,25 @@ This repository contains a simple web-based application for managing bills at a 
 To use, open `index.html` in a browser. Default login credentials:
 - **Email**: `admin@karaoke.jp`
 - **Password**: `12345678`
+
+## Usage
+
+1. Open `index.html` in your web browser and log in using the credentials above.
+2. After logging in, choose **伝票** to open the bill management screen.
+
+### Creating and starting a bill
+
+1. Click **新規伝票**.
+2. Enter a bill name, select a seat and adjust the guest and plan counts.
+3. Press **開始** to start the bill. The bill is saved locally and becomes active.
+
+### Viewing active bills
+
+1. From the bill management screen, select **入店中**.
+2. The active bills page lists all bills currently in progress. Each entry shows the bill number and total amount.
+3. Use the **清算** button next to a bill to mark it as paid.
+
+### Settled bills
+
+1. Once a bill is settled, it no longer appears in the active list.
+2. Select **清算済** from the bill management screen to view a list of paid bills.

--- a/active.html
+++ b/active.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Active Bills</title>
+</head>
+<body>
+    <h1>入店中の伝票</h1>
+    <div id="active-list"></div>
+    <button onclick="window.location.href='bills.html'">戻る</button>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -233,8 +233,66 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    const inStoreBtn = document.getElementById('in-store');
+    if (inStoreBtn) {
+        inStoreBtn.addEventListener('click', () => {
+            window.location.href = 'active.html';
+        });
+    }
+
+    const paidBtn = document.getElementById('paid');
+    if (paidBtn) {
+        paidBtn.addEventListener('click', () => {
+            window.location.href = 'paid.html';
+        });
+    }
+
     const startBtn = document.getElementById('start-btn');
     if (startBtn) {
         initNewBillPage();
     }
+
+    const activeList = document.getElementById('active-list');
+    if (activeList) {
+        initActivePage();
+    }
+
+    const paidList = document.getElementById('paid-list');
+    if (paidList) {
+        initPaidPage();
+    }
 });
+
+function renderBillRow(container, bill, onSettle) {
+    const div = document.createElement('div');
+    div.textContent = `${bill.id} ${bill.name} 合計${bill.total}円`;
+    if (onSettle) {
+        const btn = document.createElement('button');
+        btn.textContent = '清算';
+        btn.addEventListener('click', () => onSettle(bill));
+        div.appendChild(btn);
+    }
+    container.appendChild(div);
+}
+
+function initActivePage() {
+    const container = document.getElementById('active-list');
+    const bills = loadBills('bills');
+    container.innerHTML = '';
+    bills.filter(b => b.status === 'active').forEach(bill => {
+        renderBillRow(container, bill, billToSettle => {
+            billToSettle.status = 'paid';
+            saveBills('bills', bills);
+            initActivePage();
+        });
+    });
+}
+
+function initPaidPage() {
+    const container = document.getElementById('paid-list');
+    const bills = loadBills('bills');
+    container.innerHTML = '';
+    bills.filter(b => b.status === 'paid').forEach(bill => {
+        renderBillRow(container, bill);
+    });
+}

--- a/paid.html
+++ b/paid.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Paid Bills</title>
+</head>
+<body>
+    <h1>清算済の伝票</h1>
+    <div id="paid-list"></div>
+    <button onclick="window.location.href='bills.html'">戻る</button>
+    <script src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document how to run and operate the bill management screens
- add pages for active and paid bills
- implement simple display/settle logic

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842951316608333a050cb2dd9d418fe