### PR TITLE
Improve layout for dynamic input rows

### DIFF
--- a/main.js
+++ b/main.js
@@ -170,6 +170,7 @@ function initNewBillPage(editId) {
     document.getElementById('add-optional-plan').addEventListener('click', () => {
         const container = document.getElementById('optional-plans-container');
         const div = document.createElement('div');
+        div.classList.add('flex-row');
         const nameInput = document.createElement('input');
         nameInput.placeholder = '項目';
         const priceInput = document.createElement('input');
@@ -227,6 +228,7 @@ function initNewBillPage(editId) {
 
     function createStaffRow(container, price, array) {
         const div = document.createElement('div');
+        div.classList.add('flex-row');
         const nameInput = document.createElement('input');
         nameInput.setAttribute('list', container.id + '-list');
         const dec = document.createElement('button');

--- a/new.html
+++ b/new.html
@@ -8,6 +8,18 @@
         body { font-family: sans-serif; margin: 1em; }
         .section { margin-bottom: 1em; }
         .counter { display: flex; align-items: center; gap: 0.5em; }
+        .flex-row {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+        }
+        .flex-row input,
+        .flex-row select {
+            flex: 1 1 auto;
+            min-width: 80px;
+            max-width: 150px;
+        }
         .discount { color: red; }
         @media (min-width: 600px) { .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1em; } }
         @media (min-width: 900px) { .grid { grid-template-columns: repeat(3,1fr); } }


### PR DESCRIPTION
## Summary
- add `.flex-row` style for responsive input layout
- apply `.flex-row` to optional plan and staff rows

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6842abf351e883339944f1a8682120c1