### PR TITLE
Update README for early exit and save requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ To use, open `index.html` in a browser. Default login credentials:
 ### Creating and starting a bill
 
 1. Click **新規伝票**.
-2. Enter a bill name, select a seat and adjust the guest and plan counts.
+2. Enter a bill name, select a seat and adjust the guest and plan counts. Each guest line includes a **早退** button that records the time a guest leaves early; press it again to cancel the early exit.
 3. Press **開始** to start the bill. A bill number is generated at this time and the bill is saved locally as active.
 
 ### Viewing active bills
 
 1. From the bill management screen, select **入店中**.
 2. The active bills page lists all bills currently in progress. Each entry shows the bill number and total amount.
-3. Use the **編集** button to open the bill in the creation screen where all details can be changed. Use **清算** to mark the bill as paid.
+3. Use the **編集** button to open the bill in the creation screen where all details can be changed. After making adjustments, press **保存** to keep the updates. Use **清算** to mark the bill as paid.
 
 ### Settled bills
 


### PR DESCRIPTION
## Summary
- document the early-exit ("早退") button in bill creation
- note that "保存" must be pressed after editing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843e0cb24e0833395ff3c96605e4cee