### PR TITLE
Fix early exit persistence

### DIFF
--- a/main.js
+++ b/main.js
@@ -226,6 +226,7 @@ function initNewBillPage(editId) {
             }
             updateEarlyDisplay();
             updateTotal();
+            saveBills('bills', bills);
         });
 
         const removeBtn = document.createElement('button');


### PR DESCRIPTION
## Summary
- persist bill state when toggling early exit in the new bill page

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_6843e0c9d0348333808141fe1f755ef5